### PR TITLE
Export Mutex from the package index

### DIFF
--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -1,0 +1,13 @@
+import {Mutex, ReadersWriterLock} from "../src/index.js"
+
+describe("epic-locks index", () => {
+  it("exports Mutex", () => {
+    expect(typeof Mutex).toEqual("function")
+    expect(new Mutex() instanceof Mutex).toEqual(true)
+  })
+
+  it("exports ReadersWriterLock", () => {
+    expect(typeof ReadersWriterLock).toEqual("function")
+    expect(new ReadersWriterLock() instanceof ReadersWriterLock).toEqual(true)
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 /** @module epic-locks */
+import Mutex from "./mutex.js"
 import ReadersWriterLock from "./readers-writer-lock.js"
 
 export {
+  Mutex,
   ReadersWriterLock
 }


### PR DESCRIPTION
## Why
`Mutex` (a sequential async lock — run one async job at a time) already exists in the package (`src/mutex.js`) and is tested (`spec/mutex-spec.js`), but the package index only exported `ReadersWriterLock`. Consumers who wanted the plain mutex had to deep-import its build file.

This came up serializing native SQLite queries in velocious (concurrent `getAllAsync` on one connection races expo-sqlite's shared statement) — a plain `Mutex.sync(...)` is exactly the right primitive, and `ReadersWriterLock` isn't (it allows parallel reads).

## Change
- Export `Mutex` from `src/index.js` alongside `ReadersWriterLock`, so `import {Mutex} from "epic-locks"` works.
- Add `spec/index-spec.js` asserting both `Mutex` and `ReadersWriterLock` are exported and constructable.

No behavior change to either lock. `build/` is gitignored and regenerated on publish (`prepublishOnly`).

## Verification
- `npm run build` (tsc) green; `npm test` (jasmine) green — 8 specs, 0 failures (incl. the new index spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)