### PR TITLE
Add release-patch for release:patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "eslint": "^10.2.0",
         "eslint-plugin-jsdoc": "^63.0.8",
         "jasmine": "^6.0.0",
+        "release-patch": "^1.0.0",
         "typescript": "^6.0.2"
       }
     },
@@ -1337,6 +1338,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/release-patch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/release-patch/-/release-patch-1.0.1.tgz",
+      "integrity": "sha512-sdXCYr4NjCBWn+Bpc8bzLAAuDNSRBF8nggCg8iATGiTAfMfPCWfN9H+n9rq4s+23SLEwQG7Q4RwioQqkvZynGw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "release-patch": "bin/release-patch.js"
       }
     },
     "node_modules/reserved-identifiers": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc",
     "lint": "npm run eslint && npm run typecheck",
     "prepublishOnly": "npm run build",
+    "release:patch": "release-patch",
     "test": "jasmine",
     "typecheck": "tsc --noEmit",
     "eslint": "eslint ."
@@ -31,6 +32,7 @@
     "eslint": "^10.2.0",
     "eslint-plugin-jsdoc": "^63.0.8",
     "jasmine": "^6.0.0",
+    "release-patch": "^1.0.0",
     "typescript": "^6.0.2"
   }
 }


### PR DESCRIPTION
## Why
epic-locks had no release script, so it couldn't be version-bumped/tagged/published the way our other libraries are.

## Change
- Add `release-patch` (`^1.0.0`) as a dev dependency and a `"release:patch": "release-patch"` script, matching haya-select / haya-date-picker / velocious.

## Verification
- `npm install` updates the lockfile; `node_modules/.bin/release-patch` is available; `npm test` (jasmine) green — 6 specs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
